### PR TITLE
use relative import for Palette

### DIFF
--- a/pixoo/simulator.py
+++ b/pixoo/simulator.py
@@ -2,7 +2,7 @@ import tkinter
 
 from PIL import ImageTk, Image, ImageDraw
 
-from . import Palette
+from ._colors import Palette
 
 
 class SimulatorConfig:

--- a/pixoo/simulator.py
+++ b/pixoo/simulator.py
@@ -2,7 +2,7 @@ import tkinter
 
 from PIL import ImageTk, Image, ImageDraw
 
-from pixoo import Palette
+from . import Palette
 
 
 class SimulatorConfig:


### PR DESCRIPTION
Hey there,

the simulator should use a relative import for `Palette` (which is in the same package).
Otherwise you'll run into trouble when using this library as a git-submodule (see: https://github.com/4ch1m/pixoo-rest/issues/4).

Thanks a bunch!

P.S.: The simulator is a useful addition. :+1:  