### PR TITLE
Auto identify Pixoo devices in network

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,6 +59,14 @@ brew install python-tk
 
 Create an interface with your device as such (of course use your own local IP-address):
 
+If you don't know your device IP and you have just one Pixoo device in your network, you can skip the address
+argument and Pixoo will automatically identify the device in your network and use that address for the connection.
+
+```python
+pixoo = Pixoo()
+```
+
+If you know your Pixoo device IP or you have more than one device in your network, you can enter teh device local address.
 ```python
 pixoo = Pixoo('192.168.1.137')
 ```

--- a/pixoo/api.py
+++ b/pixoo/api.py
@@ -4,6 +4,11 @@ import requests
 import pixoo.exceptions as _exceptions
 
 
+def _snake_to_camel(string):
+    """ Convert string from snake_case to camelCase """
+    return "".join(word.title() for word in string.split("_"))
+
+
 class ApiResponse:
     """ Automatic check of Pixoo API response """
     def __init__(self, api_response: requests.models.Response):
@@ -20,3 +25,31 @@ class ApiResponse:
     def data(self):
         """ Return API response (just json data) """
         return self.__data
+
+
+def _get_cmd_response(api_response: requests.models.Response):
+    """ Validate response of Pixoo API command """
+    response = api_response.json()
+    if "error_code" in response:
+        if response["error_code"] != 0:
+            raise _exceptions.InvalidApiResponse(
+                f"Command error code is not 0. Error Code: {response['error_code']} ({response['error_message']})")  # pylint: disable=line-too-long
+    return response
+
+
+class PixooBaseApi:
+    # pylint: disable=too-few-public-methods
+    """ Talk with Pixoo API """
+    def __init__(self, address: str):
+        self.__address = address
+
+    def send_command(self, command: str, timeout=60, **arguments):
+        """ Send command to Pixoo API """
+        # Prepare data to send. Command is the first item in the dict
+        data = {"Command": command}
+        # Send arguments taken in snake_case to camelCase
+        for arg, value in arguments.items():
+            data.update({_snake_to_camel(arg): value})
+        response = requests.post(
+            f"http://{self.__address}/post", json=data, timeout=timeout)
+        return _get_cmd_response(response)

--- a/pixoo/api.py
+++ b/pixoo/api.py
@@ -1,0 +1,22 @@
+#!/bin/python3
+""" Better interaction with request module and pixoo API """
+import requests
+import pixoo.exceptions as _exceptions
+
+
+class ApiResponse:
+    """ Automatic check of Pixoo API response """
+    def __init__(self, api_response: requests.models.Response):
+        self.__data = self.__validate_response(api_response)
+
+    def __validate_response(self, api_response):
+        response = api_response.json()
+        if response["ReturnCode"] != 0:
+            raise _exceptions.InvalidApiResponse(
+                f"API Return code is not 0. Return Code: {response['ReturnCode']} ({response['ReturnMessage']})")  # pylint: disable=line-too-long
+        return response
+
+    @property
+    def data(self):
+        """ Return API response (just json data) """
+        return self.__data

--- a/pixoo/exceptions.py
+++ b/pixoo/exceptions.py
@@ -1,0 +1,14 @@
+#!/binpython3
+""" Pixoo package exceptions """
+
+
+class InvalidApiResponse(RuntimeError):
+    """ Raise this exception when return code is not valid from Pixoo API """
+
+
+class NoPixooDevicesFound(RuntimeError):
+    """ No pixoo devices found in local network """
+
+
+class MoreThanOnePixooFound(RuntimeError):
+    """ More than one pixoo device found in netwoork """

--- a/pixoo/find_device.py
+++ b/pixoo/find_device.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+""" Discovers pixoo devices in your local network and their IPs.
+
+This module is used to find pixoo devices in your local network to later use
+them by the Pixoo library
+"""
+import requests as _requests
+from pixoo.api import ApiResponse as _ApiResponse
+import pixoo.exceptions as _exceptions
+
+
+def get_pixoo_devices():
+    """ Get Pixoo devices detected in your local network """
+    # This method is using the 'Find device' documentation from:
+    #   http://doc.divoom-gz.com/web/#/12?page_id=336
+    response = _ApiResponse(_requests.post(
+        "https://app.divoom-gz.com/Device/ReturnSameLANDevice",
+        timeout=100,
+    ))
+    device_list = response.data["DeviceList"]
+    if len(device_list) == 0:
+        raise _exceptions.NoPixooDevicesFound
+    return device_list
+
+
+def show_pixoo_devices():
+    """ Show information of pixoo devices in local network """
+    pixoo_devices = get_pixoo_devices()
+    print(f" Pixo Devices ({len(pixoo_devices)})".center(40, "-"))
+    for index, pixoo_device in enumerate(pixoo_devices):
+        dev_name = pixoo_device["DeviceName"]
+        dev_ip = pixoo_device["DevicePrivateIP"]
+        print(f"  {index + 1}.- {dev_name} (IP: {dev_ip})")
+    print("-" * 40)


### PR DESCRIPTION
Hello!!
I have a created a small method that runs the API to identify devices in the local network.

Additionally, I have made `address` an optional argument when creating a Pixoo device, so that in case there is 1 device in the local network, we can use it without asking the user to directly enter the device IP.

I have also added this feature as part of the documentation in the README.md file.

This is how it looks like when we don't pass an address in the constructor.

```
>>> from pixoo import Pixoo
>>> pixo = Pixoo()
 Pixo Device auto identified!!! DeviceName: Pixoo64 (IP: 192.168.1.99)
>>> 
```